### PR TITLE
Fix to JS String.replace default behavior

### DIFF
--- a/src/url-formatter.test.ts
+++ b/src/url-formatter.test.ts
@@ -6,13 +6,13 @@ describe('interceptorUrlFormatter', () => {
   test('replaces {tokens} in url and removes used params', () => {
     const config: AxiosRequestConfig = {
       params: {
-        id: '12345',
+        id: '$$12345',
         unusedParam: 'test',
       },
       url: 'http://localhost:3000/{id}',
     }
     const configUpd = interceptorUrlFormatter(config)
-    expect(configUpd.url).toBe('http://localhost:3000/12345')
+    expect(configUpd.url).toBe('http://localhost:3000/$$12345')
     expect(typeof configUpd.params).toBe('object')
     expect(Object.keys(configUpd.params).length).toBe(1)
     expect(configUpd.params).toHaveProperty('unusedParam', config.params.unusedParam)

--- a/src/url-formatter.ts
+++ b/src/url-formatter.ts
@@ -40,7 +40,7 @@ export const interceptorUrlFormatter = (config: AxiosRequestConfig): AxiosReques
   for (const paramName of Object.keys(config.params)) {
     const param = config.params[paramName]
     if (config.url && config.url.indexOf(`{${paramName}}`) > -1) {
-      config.url = config.url.replace(`{${paramName}}`, function () { return param })
+      config.url = config.url.replace(`{${paramName}}`, () => param)
       delete config.params[paramName]
     }
   }

--- a/src/url-formatter.ts
+++ b/src/url-formatter.ts
@@ -40,7 +40,7 @@ export const interceptorUrlFormatter = (config: AxiosRequestConfig): AxiosReques
   for (const paramName of Object.keys(config.params)) {
     const param = config.params[paramName]
     if (config.url && config.url.indexOf(`{${paramName}}`) > -1) {
-      config.url = config.url.replace(`{${paramName}}`, param)
+      config.url = config.url.replace(`{${paramName}}`, function () { return param })
       delete config.params[paramName]
     }
   }


### PR DESCRIPTION
Any param string that happens to include consecutive dollar-signs will lack one dollar sign and result in incorrect URIs